### PR TITLE
Add basic docker deployment using docker-compose [RDO-29]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+context/installer/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @najlepsiwebdesigner @PhotoTeeborChoka @canikrichard

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:experimental
+
+FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04
+
+USER root
+SHELL ["/bin/bash", "-c"]
+
+COPY installer/phoxi.run /tmp/phoxi.run
+COPY system_files/PhoXiControl /usr/local/bin/PhoXiControl
+
+ENV PHOXI_CONTROL_PATH="/opt/Photoneo/PhoXiControl"
+
+RUN set -eux \
+    && cd /tmp \
+    && apt-get update -y \
+    && apt-get install -y -q software-properties-common && apt-add-repository universe \
+    && apt-get update -y \
+    # phoxicontrol dependencies (gui...)
+    && apt install -y avahi-utils libqt5core5a libqt5dbus5 libqt5gui5 libgtk2.0-0 libssl1.0.0 libgomp1 libpcre16-3 libflann-dev libssh2-1-dev libpng16-16 libglfw3-dev \
+    && chmod a+x phoxi.run \
+    && ./phoxi.run --accept ${PHOXI_CONTROL_PATH} \
+    && rm -rf phoxi.run
+
+CMD ["/usr/local/bin/PhoXiControl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-# syntax=docker/dockerfile:experimental
-
-FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04
+FROM ubuntu:18.04
 
 USER root
-SHELL ["/bin/bash", "-c"]
+
+RUN set -eux \
+    && apt-get update -y \
+    && apt-get install -y -q software-properties-common && apt-add-repository universe \
+    && apt-get update -y \
+    # phoxicontrol dependencies (gui...)
+    && apt install -y avahi-utils libqt5core5a libqt5dbus5 libqt5gui5 libgtk2.0-0 libssl1.0.0 libgomp1 libpcre16-3 libflann-dev libssh2-1-dev libpng16-16 libglfw3-dev xcb
 
 COPY installer/phoxi.run /tmp/phoxi.run
 COPY system_files/PhoXiControl /usr/local/bin/PhoXiControl
@@ -12,13 +16,12 @@ ENV PHOXI_CONTROL_PATH="/opt/Photoneo/PhoXiControl"
 
 RUN set -eux \
     && cd /tmp \
-    && apt-get update -y \
-    && apt-get install -y -q software-properties-common && apt-add-repository universe \
-    && apt-get update -y \
-    # phoxicontrol dependencies (gui...)
-    && apt install -y avahi-utils libqt5core5a libqt5dbus5 libqt5gui5 libgtk2.0-0 libssl1.0.0 libgomp1 libpcre16-3 libflann-dev libssh2-1-dev libpng16-16 libglfw3-dev \
     && chmod a+x phoxi.run \
     && ./phoxi.run --accept ${PHOXI_CONTROL_PATH} \
     && rm -rf phoxi.run
+
+# TODO: this is a bug SCAN-3548
+RUN set -eux \
+    && mkdir /root/.PhotoneoPhoXiControl
 
 CMD ["/usr/local/bin/PhoXiControl"]

--- a/README.md
+++ b/README.md
@@ -1,63 +1,11 @@
 # PhoXiControl inside the docker image
 This is a short manual on deploying the PhoXiControl inside the a docker image
 
-## Before build
-Select a desired Ubuntu 18.04 installer and copy it to the `context/installer/phoxi.run` file.
-
-### Install nvidia-container-runtime
-```bash
-curl -s -L https://nvidia.github.io/nvidia-container-runtime/gpgkey | sudo apt-key add -
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
-curl -s -L https://nvidia.github.io/nvidia-container-runtime/$distribution/nvidia-container-runtime.list | sudo tee /etc/apt/sources.list.d/nvidia-container-runtime.list
-sudo apt-get update
-sudo apt-get install nvidia-container-runtime
-```
-#### Update docker daemon
-Add `/etc/docker/daemon.json` file with this content
-```yml
-{
-  "runtimes": {
-  "nvidia": {
-    "path": "/usr/bin/nvidia-container-runtime",
-    "runtimeArgs": []
-    }
-  }
-}
-```
-
-#### Restart docker service
-```bash
-sudo systemctl restart docker.service
-```
-
-### Test nvidia docker
-To make sure Nvidia support works run the following docker image:
-```bash
-sudo docker run --rm --gpus all nvidia/cuda:10.0-base nvidia-smi
-```
-
-Which should result in something similar output:
-
-```
-+-----------------------------------------------------------------------------+
-| NVIDIA-SMI 418.56       Driver Version: 418.56       CUDA Version: 10.1     |
-|-------------------------------+----------------------+----------------------+
-| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
-| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
-|===============================+======================+======================|
-|   0  GeForce RTX 2060    Off  | 00000000:01:00.0  On |                  N/A |
-| N/A   57C    P8     7W /  N/A |   1586MiB /  5904MiB |      6%      Default |
-+-------------------------------+----------------------+----------------------+
-
-+-----------------------------------------------------------------------------+
-| Processes:                                                       GPU Memory |
-|  GPU       PID   Type   Process name                             Usage      |
-|=============================================================================|
-+-----------------------------------------------------------------------------+
-```
 
 
 ## Build
+
+Select a desired Ubuntu 18.04 installer and copy it to the `context/installer/phoxi.run` file.
 
 Once the installer is present, proceed with the image build process:
 
@@ -69,10 +17,10 @@ DOCKER_BUILDKIT=1 docker build -t "photoneo/phoxicontrol:latest" -f Dockerfile c
 
 ## Run
 
-In order to be able to run the image, `docker` must be set up to be able to pass `nvidia` runtime and you have to execute:
+In order to be able to run the image, `docker` must be set up to be able to pass X:
 
 ```bash
-xhost +
+sudo xhost +local:docker
 ```
 
 To run the image containing the PhoXiControl, use `docker-compose` inside the root of the project directory:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,100 @@
+# PhoXiControl inside the docker image
+This is a short manual on deploying the PhoXiControl inside the a docker image
+
+## Before build
+Select a desired Ubuntu 18.04 installer and copy it to the `context/installer/phoxi.run` file.
+
+### Install nvidia-container-runtime
+```bash
+curl -s -L https://nvidia.github.io/nvidia-container-runtime/gpgkey | sudo apt-key add -
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+curl -s -L https://nvidia.github.io/nvidia-container-runtime/$distribution/nvidia-container-runtime.list | sudo tee /etc/apt/sources.list.d/nvidia-container-runtime.list
+sudo apt-get update
+sudo apt-get install nvidia-container-runtime
+```
+#### Update docker daemon
+Add `/etc/docker/daemon.json` file with this content
+```yml
+{
+  "runtimes": {
+  "nvidia": {
+    "path": "/usr/bin/nvidia-container-runtime",
+    "runtimeArgs": []
+    }
+  }
+}
+```
+
+#### Restart docker service
+```bash
+sudo systemctl restart docker.service
+```
+
+### Test nvidia docker
+To make sure Nvidia support works run the following docker image:
+```bash
+sudo docker run --rm --gpus all nvidia/cuda:10.0-base nvidia-smi
+```
+
+Which should result in something similar output:
+
+```
++-----------------------------------------------------------------------------+
+| NVIDIA-SMI 418.56       Driver Version: 418.56       CUDA Version: 10.1     |
+|-------------------------------+----------------------+----------------------+
+| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
+|===============================+======================+======================|
+|   0  GeForce RTX 2060    Off  | 00000000:01:00.0  On |                  N/A |
+| N/A   57C    P8     7W /  N/A |   1586MiB /  5904MiB |      6%      Default |
++-------------------------------+----------------------+----------------------+
+
++-----------------------------------------------------------------------------+
+| Processes:                                                       GPU Memory |
+|  GPU       PID   Type   Process name                             Usage      |
+|=============================================================================|
++-----------------------------------------------------------------------------+
+```
+
+
+## Build
+
+Once the installer is present, proceed with the image build process:
+
+```bash
+DOCKER_BUILDKIT=1 docker build -t "photoneo/phoxicontrol:latest" -f Dockerfile context
+```
+
+
+
+## Run
+
+In order to be able to run the image, `docker` must be set up to be able to pass `nvidia` runtime and you have to execute:
+
+```bash
+xhost +
+```
+
+To run the image containing the PhoXiControl, use `docker-compose` inside the root of the project directory:
+
+```bash
+ docker-compose up -d
+```
+
+The running image will display the PhoXiControl GUI.
+
+
+
+## Stop
+
+To stop the running PhoXiControl image, use `docker-compose` inside the root of the project directory:
+
+```bash
+docker-compose down
+```
+
+
+
+## Notes
+
+Consider mounting the scans directory using a dedicated volume.

--- a/context/system_files/PhoXiControl
+++ b/context/system_files/PhoXiControl
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+LD_LIBRARY_PATH= /usr/bin/PhoXiControl "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,17 @@
-version: "2.4"
+---
+
+version: "3.6"
 
 services:
   phoxicontrol:
-    image: photoneo/phoxicontrol
-    runtime: nvidia
+    build:
+      context: ./context
+      dockerfile: $PWD/Dockerfile
+      # args:
+      #   buildno: 1
+    image: photoneo/phoxicontrol:latest
+    devices:
+      - /dev/dri:/dev/dri
     volumes:
       - /tmp/.X11-unix/:/tmp/.X11-unix
       - /var/run/dbus:/var/run/dbus
@@ -14,7 +22,7 @@ services:
       - DOCKER=1
       - QT_X11_NO_MITSHM=1
       - SHELL
-    stop_signal: SIGINT
+    stop_signal: SIGKILL
     security_opt:
       - apparmor=unconfined
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "2.4"
+
+services:
+  phoxicontrol:
+    image: photoneo/phoxicontrol
+    runtime: nvidia
+    volumes:
+      - /tmp/.X11-unix/:/tmp/.X11-unix
+      - /var/run/dbus:/var/run/dbus
+      - /dev/shm:/dev/shm
+    privileged: true
+    environment:
+      - DISPLAY
+      - DOCKER=1
+      - QT_X11_NO_MITSHM=1
+      - SHELL
+    stop_signal: SIGINT
+    security_opt:
+      - apparmor=unconfined
+    logging:
+      driver: journald
+      options:
+        tag: '{{.ImageID}}/{{.Name}}/{{.ID}}'


### PR DESCRIPTION
Formerly located as a manual here, but the link is broken and some customers request such a feature: https://www.photoneo.com/files/support/PS-Tickets/PS-5835/pxc-docker.tar.gz

Per popular request this PR introduces a basic Phoxi Control build for the docker, which can be used in place of OS installer when needed.

Please follow the README.md install instructions.